### PR TITLE
Support webpack 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,10 +5,12 @@ var path = require('path');
 var loaderUtils = require('loader-utils');
 module.exports = function() {};
 module.exports.pitch = function(request) {
+
   if (!this.webpack)
     throw new Error('Only usable with webpack');
   var callback = this.async();
-  var query = loaderUtils.parseQuery(this.query);
+  var query = loaderUtils.getOptions(this) || {};
+
   var outputOptions = {
     filename: '[hash].sharedworker.js',
     chunkFilename: '[id].[hash].sharedworker.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,41 @@
+{
+  "name": "shared-worker-loader",
+  "version": "0.3.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+    },
+    "emojis-list": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+    },
+    "json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "requires": {
+        "minimist": "^1.2.0"
+      }
+    },
+    "loader-utils": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+      "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+      "requires": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^2.0.0",
+        "json5": "^1.0.1"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared-worker-loader",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Shared Worker loader for Webpack",
   "main": "index.js",
   "repository": {
@@ -14,9 +14,9 @@
     "worker"
   ],
   "author": {
-  	"name": "Martin Broder",
-  	"email": "hello@martinbroder.com",
-  	"url": "martinbroder.com"
+    "name": "Martin Broder",
+    "email": "hello@martinbroder.com",
+    "url": "martinbroder.com"
   },
   "license": "MIT",
   "bugs": {
@@ -24,9 +24,9 @@
   },
   "homepage": "https://github.com/mrtnbroder/shared-worker-loader#readme",
   "peerDependencies": {
-		"webpack": ">=0.9 <2"
-	},
+    "webpack": ">=0.9 <5"
+  },
   "dependencies": {
-    "loader-utils": "^0.2.11"
+    "loader-utils": "^1.2.3"
   }
 }


### PR DESCRIPTION
Tested with webpack 4 and updated the package.json peer dependency.

Also updated to latest loader-utils, and fixed a null ptr error if query string is not provided.